### PR TITLE
Fix races in accessing connection and builder

### DIFF
--- a/build.go
+++ b/build.go
@@ -14,8 +14,7 @@ type DatagramBuilder struct {
 // Returns a new DatagramBuilder
 func NewDatagramBuilder() (b *DatagramBuilder) {
 	return &DatagramBuilder{
-		buffer: bytes.Buffer{},
-		crc:    NewCRC(),
+		crc: NewCRC(),
 	}
 }
 
@@ -69,7 +68,7 @@ func (r *DatagramBuilder) Bytes() []byte {
 
 // Converts the datagram into a string representation for printing
 func (r *DatagramBuilder) String() string {
-	buf := bytes.Buffer{}
+	var buf bytes.Buffer
 	buf.WriteByte(byte('['))
 	for i, b := range r.buffer.Bytes() {
 		if i != 0 {

--- a/connection.go
+++ b/connection.go
@@ -59,13 +59,13 @@ func (c *Connection) Close() {
 }
 
 // Sends the given RCT datagram via the connection
-func (c *Connection) Send(rdb *DatagramBuilder) (n int, err error) {
+func (c *Connection) Send(rdb *DatagramBuilder) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.send(rdb)
 }
 
-func (c *Connection) send(rdb *DatagramBuilder) (n int, err error) {
+func (c *Connection) send(rdb *DatagramBuilder) (int, error) {
 	// ensure active connection
 	if c.conn == nil {
 		if err := c.connect(); err != nil {
@@ -74,7 +74,7 @@ func (c *Connection) send(rdb *DatagramBuilder) (n int, err error) {
 	}
 
 	// fmt.Printf("Sending %v\n", c.Builder.String())
-	n, err = c.conn.Write(rdb.Bytes())
+	n, err := c.conn.Write(rdb.Bytes())
 	// single retry on error when sending
 	if err != nil {
 		// fmt.Printf("Read %d bytes error %v\n", n, err)
@@ -116,7 +116,7 @@ func (c *Connection) Receive() (dg *Datagram, err error) {
 }
 
 // Queries the given identifier on the RCT device, returning its value as a datagram
-func (c *Connection) Query(id Identifier) (dg *Datagram, err error) {
+func (c *Connection) Query(id Identifier) (*Datagram, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -126,12 +126,11 @@ func (c *Connection) Query(id Identifier) (dg *Datagram, err error) {
 
 	builder := NewDatagramBuilder()
 	builder.Build(&Datagram{Read, id, nil})
-	_, err = c.send(builder)
-	if err != nil {
+	if _, err := c.send(builder); err != nil {
 		return nil, err
 	}
 
-	dg, err = c.Receive()
+	dg, err := c.Receive()
 	if err != nil {
 		return nil, err
 	}

--- a/connection.go
+++ b/connection.go
@@ -90,10 +90,14 @@ func (c *Connection) send(rdb *DatagramBuilder) (int, error) {
 }
 
 // Receives an RCT response via the connection
-func (c *Connection) Receive() (dg *Datagram, err error) {
+func (c *Connection) Receive() (*Datagram, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.receive()
+}
 
+// Receives an RCT response via the connection
+func (c *Connection) receive() (dg *Datagram, err error) {
 	// ensure active connection
 	if c.conn == nil {
 		if err := c.connect(); err != nil {
@@ -130,7 +134,7 @@ func (c *Connection) Query(id Identifier) (*Datagram, error) {
 		return nil, err
 	}
 
-	dg, err := c.Receive()
+	dg, err := c.receive()
 	if err != nil {
 		return nil, err
 	}

--- a/recoverable.go
+++ b/recoverable.go
@@ -1,17 +1,11 @@
-package rct;
+package rct
 
 // Errors caused by a malformed or unexpected packet, which can be potentially be recovered by retrying the transmission
 type RecoverableError struct {
-        Err     string
+	Err string
 }
 
 // Prints error to string
 func (e RecoverableError) Error() string {
-        return e.Err
-}
-
-// Returns true if the given error is potentially recoverable
-func IsRecoverableError(err error) bool {
-        _, ok:=err.(RecoverableError)
-        return ok
+	return e.Err
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/13439

If performance is a concern one could still add a builder pool.

Also removes `IsRecoverableError` api which is equivalent to `errors.As()`.