### PR TITLE
Add streaming parser

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1,0 +1,56 @@
+package rct
+
+import "context"
+
+// Broker courtesy of https://stackoverflow.com/questions/36417199/how-to-broadcast-message-using-channel
+
+type Broker[T any] struct {
+	publishCh chan T
+	subCh     chan chan T
+	unsubCh   chan chan T
+}
+
+func NewBroker[T any]() *Broker[T] {
+	return &Broker[T]{
+		publishCh: make(chan T, 1),
+		subCh:     make(chan chan T, 1),
+		unsubCh:   make(chan chan T, 1),
+	}
+}
+
+func (b *Broker[T]) Start(ctx context.Context) {
+	subs := map[chan T]struct{}{}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msgCh := <-b.subCh:
+			subs[msgCh] = struct{}{}
+		case msgCh := <-b.unsubCh:
+			delete(subs, msgCh)
+			close(msgCh)
+		case msg := <-b.publishCh:
+			for msgCh := range subs {
+				// msgCh is buffered, use non-blocking send to protect the broker:
+				select {
+				case msgCh <- msg:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (b *Broker[T]) Subscribe() chan T {
+	msgCh := make(chan T, 5)
+	b.subCh <- msgCh
+	return msgCh
+}
+
+func (b *Broker[T]) Unsubscribe(msgCh chan T) {
+	b.unsubCh <- msgCh
+}
+
+func (b *Broker[T]) Publish(msg T) {
+	b.publishCh <- msg
+}

--- a/build.go
+++ b/build.go
@@ -2,7 +2,6 @@ package rct
 
 import (
 	"bytes"
-	"fmt"
 )
 
 // Builds RCT datagrams into an internal buffer, with escaping and CRC correction
@@ -57,18 +56,4 @@ func (rdb *DatagramBuilder) Build(dg *Datagram) {
 // Returns the datagram built so far as an array of bytes
 func (r *DatagramBuilder) Bytes() []byte {
 	return r.buffer.Bytes()
-}
-
-// Converts the datagram into a string representation for printing
-func (r *DatagramBuilder) String() string {
-	var buf bytes.Buffer
-	buf.WriteByte(byte('['))
-	for i, b := range r.buffer.Bytes() {
-		if i != 0 {
-			buf.WriteByte(byte(' '))
-		}
-		fmt.Fprintf(&buf, "%02X", b)
-	}
-	buf.WriteByte(byte(']'))
-	return buf.String()
 }

--- a/build.go
+++ b/build.go
@@ -8,14 +8,7 @@ import (
 // Builds RCT datagrams into an internal buffer, with escaping and CRC correction
 type DatagramBuilder struct {
 	buffer bytes.Buffer
-	crc    *CRC
-}
-
-// Returns a new DatagramBuilder
-func NewDatagramBuilder() (b *DatagramBuilder) {
-	return &DatagramBuilder{
-		crc: NewCRC(),
-	}
+	crc    CRC
 }
 
 // Resets the internal buffer and CRC

--- a/build_test.go
+++ b/build_test.go
@@ -1,15 +1,18 @@
 package rct
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 type builderTestCase struct {
 	Dg     Datagram
-	Expect string
+	Expect []byte
 }
 
 var builderTestCases = []builderTestCase{
-	{Datagram{Read, BatteryPowerW, nil}, "[2B 01 04 40 0F 01 5B 58 B4]"},
-	{Datagram{Read, InverterACPowerW, nil}, "[2B 01 04 DB 2D 2D 69 AE 55 AB]"},
+	{Datagram{Read, BatteryPowerW, nil}, []byte{0x2B, 0x01, 0x04, 0x40, 0x0F, 0x01, 0x5B, 0x58, 0xB4}},
+	{Datagram{Read, InverterACPowerW, nil}, []byte{0x2B, 0x01, 0x04, 0xDB, 0x2D, 0x2D, 0x69, 0xAE, 0x55, 0xAB}},
 }
 
 // Test if builder returns expected byte representation
@@ -17,8 +20,8 @@ func TestBuilder(t *testing.T) {
 	builder := new(DatagramBuilder)
 	for _, tc := range builderTestCases {
 		builder.Build(&tc.Dg)
-		res := builder.String()
-		if res != tc.Expect {
+		res := builder.Bytes()
+		if slices.Compare(res, tc.Expect) != 0 {
 			t.Errorf("error got %s, should be %s", res, tc.Expect)
 		}
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -14,7 +14,7 @@ var builderTestCases = []builderTestCase{
 
 // Test if builder returns expected byte representation
 func TestBuilder(t *testing.T) {
-	builder := NewDatagramBuilder()
+	builder := new(DatagramBuilder)
 	for _, tc := range builderTestCases {
 		builder.Build(&tc.Dg)
 		res := builder.String()
@@ -26,7 +26,7 @@ func TestBuilder(t *testing.T) {
 
 // Test if roundtrip from builder to parser returns the same datagram
 func TestBuilderParser(t *testing.T) {
-	builder := NewDatagramBuilder()
+	builder := new(DatagramBuilder)
 	parser := NewDatagramParser()
 
 	for _, tc := range builderTestCases {

--- a/cache.go
+++ b/cache.go
@@ -12,18 +12,18 @@ type entry struct {
 }
 
 // A datagram cache
-type Cache struct {
+type cache struct {
 	mu   sync.RWMutex
 	data map[Identifier]entry
 }
 
 // Creates a new datagram cache
-func NewCache() *Cache {
-	return &Cache{data: make(map[Identifier]entry)}
+func newCache() *cache {
+	return &cache{data: make(map[Identifier]entry)}
 }
 
-// Returns cache entry for the given identifier
-func (c *Cache) Get(id Identifier) (*Datagram, time.Time) {
+// Returns datagram and timestamp for the given identifier
+func (c *cache) Get(id Identifier) (*Datagram, time.Time) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	entry := c.data[id]
@@ -31,7 +31,7 @@ func (c *Cache) Get(id Identifier) (*Datagram, time.Time) {
 }
 
 // Puts given datagram into the cache, for the identifier contained in the datagram
-func (c *Cache) Put(dg *Datagram) {
+func (c *cache) Put(dg *Datagram) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.data[dg.Id] = entry{dg, time.Now()}

--- a/cache.go
+++ b/cache.go
@@ -22,7 +22,7 @@ func NewCache() *Cache {
 	return &Cache{data: make(map[Identifier]entry)}
 }
 
-// Returns cache entry for the given identifier, if still valid under timeout
+// Returns cache entry for the given identifier
 func (c *Cache) Get(id Identifier) (*Datagram, time.Time) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/connection.go
+++ b/connection.go
@@ -128,7 +128,6 @@ func (c *Connection) receive(ctx context.Context, addr string, bufC chan<- byte,
 			continue
 		}
 
-		conn.SetReadDeadline(time.Now().Add(DialTimeout))
 		n, err := conn.Read(buf)
 		if err != nil {
 			c.mu.Lock()

--- a/connection.go
+++ b/connection.go
@@ -99,7 +99,7 @@ INIT:
 
 	go conn.broker.Start(ctx)
 	go ParseStream(ctx, bufC, conn.broker.PublishChan())
-	go conn.handle(ctx, conn.broker.Subscribe(), errC)
+	go conn.handle(ctx, conn.broker.Subscribe())
 
 	if conn.logger != nil {
 		go func() {
@@ -171,7 +171,7 @@ func (c *Connection) connect(ctx context.Context, addr string) (net.Conn, error)
 	return conn, err
 }
 
-func (c *Connection) handle(ctx context.Context, dgC <-chan *Datagram, errC chan<- error) {
+func (c *Connection) handle(ctx context.Context, dgC <-chan *Datagram) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/connection.go
+++ b/connection.go
@@ -55,6 +55,11 @@ func (c *Connection) connect() (err error) {
 }
 
 // Closes the RCT device connection
+func (c *Connection) Conn() net.Conn {
+	return c.conn
+}
+
+// Closes the RCT device connection
 func (c *Connection) Close() {
 	c.conn.Close()
 	c.conn = nil
@@ -142,7 +147,7 @@ func (c *Connection) Query(id Identifier) (*Datagram, error) {
 		return nil, err
 	}
 	if dg.Cmd != Response || dg.Id != id {
-		return nil, RecoverableError{fmt.Sprintf("invalid response to read of %08X: %v", id, dg)}
+		return nil, &RecoverableError{fmt.Sprintf("invalid response to read of %08X: %v", id, dg)}
 	}
 	c.cache.Put(dg)
 

--- a/connection.go
+++ b/connection.go
@@ -96,10 +96,9 @@ func (c *Connection) receive(ctx context.Context, addr string, bufC chan<- byte,
 					return 0, err
 				}
 			}
-			conn := c.conn
 			c.mu.Unlock()
 
-			return conn.Read(buf)
+			return c.conn.Read(buf)
 		})
 		if err != nil {
 			c.mu.Lock()

--- a/connection.go
+++ b/connection.go
@@ -96,9 +96,10 @@ func (c *Connection) receive(ctx context.Context, addr string, bufC chan<- byte,
 					return 0, err
 				}
 			}
+			conn := c.conn
 			c.mu.Unlock()
 
-			return c.conn.Read(buf)
+			return conn.Read(buf)
 		})
 		if err != nil {
 			c.mu.Lock()
@@ -137,10 +138,7 @@ func (c *Connection) handle(ctx context.Context, dgC <-chan Datagram, errC chan<
 func (c *Connection) Send(rdb *DatagramBuilder) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.send(rdb)
-}
 
-func (c *Connection) send(rdb *DatagramBuilder) (int, error) {
 	// ensure active connection
 	if c.conn == nil {
 		return 0, errors.New("disconnected")

--- a/connection.go
+++ b/connection.go
@@ -90,7 +90,9 @@ func (c *Connection) receive(ctx context.Context, addr string, bufC chan<- byte,
 			if c.conn == nil {
 				var d net.Dialer
 
-				ctx, _ := context.WithTimeout(ctx, DialTimeout)
+				ctx, cancel := context.WithTimeout(ctx, DialTimeout)
+				defer cancel()
+
 				c.conn, err = d.DialContext(ctx, "tcp", addr)
 				if err != nil {
 					return 0, err

--- a/datagram.go
+++ b/datagram.go
@@ -217,9 +217,17 @@ type Datagram struct {
 	Data []byte
 }
 
+func (d *Datagram) Clone() *Datagram {
+	return &Datagram{
+		Cmd:  d.Cmd,
+		Id:   d.Id,
+		Data: append([]byte(nil), d.Data...),
+	}
+}
+
 // Prints a RCT datagram in a human-readable representation
 func (d *Datagram) String() string {
-	l := min(24, len(d.Data))
+	l := min(20, len(d.Data))
 	data := fmt.Sprintf("% x", d.Data[:l])
 	if l < len(d.Data) {
 		data += fmt.Sprintf(" ... (%d)", len(d.Data))

--- a/datagram.go
+++ b/datagram.go
@@ -219,7 +219,7 @@ type Datagram struct {
 
 // Prints a RCT datagram in a human-readable representation
 func (d *Datagram) String() string {
-	l := min(32, len(d.Data))
+	l := min(24, len(d.Data))
 	data := fmt.Sprintf("% x", d.Data[:l])
 	if l < len(d.Data) {
 		data += fmt.Sprintf(" ... (%d)", len(d.Data))

--- a/datagram.go
+++ b/datagram.go
@@ -225,7 +225,7 @@ func (d *Datagram) String() string {
 // Returns datagram body value as a float32
 func (d *Datagram) Float32() (val float32, err error) {
 	if len(d.Data) != 4 {
-		return 0, RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
+		return 0, &RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
 	}
 
 	return math.Float32frombits(binary.BigEndian.Uint32(d.Data)), nil
@@ -234,7 +234,7 @@ func (d *Datagram) Float32() (val float32, err error) {
 // Returns datagram body value as an int32
 func (d *Datagram) Int32() (val int32, err error) {
 	if len(d.Data) != 4 {
-		return 0, RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
+		return 0, &RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
 	}
 
 	return int32(binary.BigEndian.Uint32(d.Data)), nil
@@ -243,7 +243,7 @@ func (d *Datagram) Int32() (val int32, err error) {
 // Returns datagram body value as a uint16
 func (d *Datagram) Uint16() (val uint16, err error) {
 	if len(d.Data) != 2 {
-		return 0, RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
+		return 0, &RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
 	}
 
 	return binary.BigEndian.Uint16(d.Data), nil
@@ -252,7 +252,7 @@ func (d *Datagram) Uint16() (val uint16, err error) {
 // Returns datagram body value as a uint8
 func (d *Datagram) Uint8() (val uint8, err error) {
 	if len(d.Data) != 1 {
-		return 0, RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
+		return 0, &RecoverableError{fmt.Sprintf("invalid data length %d", len(d.Data))}
 	}
 
 	return uint8(d.Data[0]), nil

--- a/datagram.go
+++ b/datagram.go
@@ -219,7 +219,13 @@ type Datagram struct {
 
 // Prints a RCT datagram in a human-readable representation
 func (d *Datagram) String() string {
-	return fmt.Sprintf("Cmd %s (%02X) Id %s (%08X) Data %v", d.Cmd.String(), uint8(d.Cmd), d.Id.String(), uint32(d.Id), d.Data)
+	l := min(32, len(d.Data))
+	data := fmt.Sprintf("% x", d.Data[:l])
+	if l < len(d.Data) {
+		data += fmt.Sprintf(" ... (%d)", len(d.Data))
+	}
+
+	return fmt.Sprintf("(%02X) %s (%08X) %s [%s]", uint8(d.Cmd), d.Cmd.String(), uint32(d.Id), d.Id.String(), data)
 }
 
 // Returns datagram body value as a float32

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/mlnoga/rct
 
 go 1.23
 
-toolchain go1.24.0
-
 require github.com/cenkalti/backoff/v5 v5.0.2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/mlnoga/rct
 
-go 1.17
+go 1.23
+
+toolchain go1.24.0
+
+require github.com/cenkalti/backoff/v5 v5.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/internal/broker.go
+++ b/internal/broker.go
@@ -51,6 +51,10 @@ func (b *Broker[T]) Unsubscribe(msgCh chan T) {
 	b.unsubCh <- msgCh
 }
 
+func (b *Broker[T]) Publish(val T) {
+	b.publishCh <- val
+}
+
 func (b *Broker[T]) PublishChan() chan<- T {
 	return b.publishCh
 }

--- a/internal/broker.go
+++ b/internal/broker.go
@@ -1,6 +1,8 @@
 package internal
 
-import "context"
+import (
+	"context"
+)
 
 // Broker courtesy of https://stackoverflow.com/questions/36417199/how-to-broadcast-message-using-channel
 
@@ -13,7 +15,7 @@ type Broker[T any] struct {
 func NewBroker[T any]() *Broker[T] {
 	return &Broker[T]{
 		publishCh: make(chan T, 1),
-		subCh:     make(chan chan T, 1),
+		subCh:     make(chan chan T),
 		unsubCh:   make(chan chan T, 1),
 	}
 }

--- a/internal/broker.go
+++ b/internal/broker.go
@@ -1,4 +1,4 @@
-package rct
+package internal
 
 import "context"
 
@@ -51,6 +51,6 @@ func (b *Broker[T]) Unsubscribe(msgCh chan T) {
 	b.unsubCh <- msgCh
 }
 
-func (b *Broker[T]) Publish(msg T) {
-	b.publishCh <- msg
+func (b *Broker[T]) PublishChan() chan<- T {
+	return b.publishCh
 }

--- a/internal/broker_test.go
+++ b/internal/broker_test.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestBroker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	b := NewBroker[int]()
+	go b.Start(ctx)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				b.Publish(rand.Intn(100))
+			}
+		}
+	}()
+
+	for {
+		go func(dataC chan int) {
+			defer b.Unsubscribe(dataC)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Duration(rand.Intn(100)) * time.Millisecond):
+				return
+			}
+		}(b.Subscribe())
+	}
+}

--- a/internal/broker_test.go
+++ b/internal/broker_test.go
@@ -12,7 +12,7 @@ func TestBroker(t *testing.T) {
 	defer cancel()
 
 	b := NewBroker[int]()
-	go b.Start(ctx)
+	go b.Start(context.TODO())
 
 	go func() {
 		for {
@@ -25,7 +25,7 @@ func TestBroker(t *testing.T) {
 		}
 	}()
 
-	for {
+	for ctx.Err() == nil {
 		go func(dataC chan int) {
 			defer b.Unsubscribe(dataC)
 			select {

--- a/parse.go
+++ b/parse.go
@@ -276,7 +276,7 @@ func ParseStream(ctx context.Context, buf <-chan byte, dgC chan<- *Datagram) {
 
 			// Done
 			state = AwaitingStart
-			dgC <- &dg
+			dgC <- dg.Clone()
 		}
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -157,7 +157,7 @@ func (p *DatagramParser) Parse() (dg *Datagram, err error) {
 }
 
 // ParseStream parses a stream of bytes into a stream of datagrams
-func ParseStream(ctx context.Context, buf <-chan byte, dgC chan<- Datagram) {
+func ParseStream(ctx context.Context, buf <-chan byte, dgC chan<- *Datagram) {
 	var (
 		b           byte
 		length      uint16
@@ -276,7 +276,7 @@ func ParseStream(ctx context.Context, buf <-chan byte, dgC chan<- Datagram) {
 
 			// Done
 			state = AwaitingStart
-			dgC <- dg
+			dgC <- &dg
 		}
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -156,8 +156,8 @@ func (p *DatagramParser) Parse() (dg *Datagram, err error) {
 	return dg, nil
 }
 
-// ParseAsync asynchronously parses a stream of bytes into datagrams
-func ParseAsync(ctx context.Context, buf <-chan byte, dgC chan<- Datagram) {
+// ParseStream parses a stream of bytes into a stream of datagrams
+func ParseStream(ctx context.Context, buf <-chan byte, dgC chan<- Datagram) {
 	var (
 		b           byte
 		length      uint16

--- a/parse.go
+++ b/parse.go
@@ -20,6 +20,7 @@ const (
 	AwaitingCrc0
 	AwaitingCrc1
 	Done
+	CRCError
 )
 
 // A parser for RCT datagrams
@@ -55,9 +56,9 @@ func (p *DatagramParser) Parse() (dg *Datagram, err error) {
 	state := AwaitingStart
 	dg = &Datagram{}
 
-	//fmt.Printf("Parser ")
+	// fmt.Printf("Parser ")
 	for _, b := range p.buffer[p.pos : p.length-p.pos] {
-		//fmt.Printf("(%v)-%02x->", state, b)
+		// fmt.Printf("(%v)-%02x->", state, b)
 
 		if !escaped {
 			if b == 0x2b {
@@ -145,10 +146,129 @@ func (p *DatagramParser) Parse() (dg *Datagram, err error) {
 			// ignore extra bytes
 		}
 	}
-	//fmt.Printf("(%v)\n", state)
+	// fmt.Printf("(%v)\n", state)
 
 	if state != Done {
-		return dg, RecoverableError{fmt.Sprintf("parsing failed in state %d", state)}
+		return dg, &RecoverableError{fmt.Sprintf("parsing failed in state %d", state)}
 	}
 	return dg, nil
+}
+
+// Parses a given transmission into a datagram
+func Parse(buf []byte) (*Datagram, int, error) {
+	var (
+		n           int
+		length      uint8
+		dataLength  uint8
+		crc         CRC
+		crcReceived uint16
+		escaped     bool
+		state       ParserState
+		dg          Datagram
+	)
+
+LOOP:
+	// fmt.Printf("Parser ")
+	for i, b := range buf {
+		n = i
+		// fmt.Printf("(%v)-%02x->", state, b)
+
+		if !escaped {
+			if b == 0x2b {
+				state = AwaitingCmd
+				continue
+			} else if b == 0x2d {
+				escaped = true
+				continue
+			}
+		} else { // escaped start or stop char
+			escaped = false
+			// fall through and process normally
+		}
+
+		switch state {
+		case AwaitingStart:
+			if b == 0x2B {
+				state = AwaitingCmd
+			}
+
+		case AwaitingCmd:
+			crc.Reset()
+			crc.Update(b)
+			dg.Cmd = Command(b)
+			if dg.Cmd <= ReadPeriodically || dg.Cmd == Extension {
+				state = AwaitingLen
+			} else {
+				state = AwaitingStart
+			}
+
+		case AwaitingLen:
+			crc.Update(b)
+			length = uint8(b)
+			dataLength = length - 4
+			state = AwaitingId0
+
+		case AwaitingId0:
+			crc.Update(b)
+			dg.Id = Identifier(uint32(b) << 24)
+			state = AwaitingId1
+
+		case AwaitingId1:
+			crc.Update(b)
+			dg.Id |= Identifier(uint32(b) << 16)
+			state = AwaitingId2
+
+		case AwaitingId2:
+			crc.Update(b)
+			dg.Id |= Identifier(uint32(b) << 8)
+			state = AwaitingId3
+
+		case AwaitingId3:
+			crc.Update(b)
+			dg.Id |= Identifier(uint32(b))
+			if dataLength > 0 {
+				dg.Data = make([]byte, 0, dataLength)
+				state = AwaitingData
+			} else {
+				dg.Data = nil
+				state = AwaitingCrc0
+			}
+
+		case AwaitingData:
+			crc.Update(b)
+			dg.Data = append(dg.Data, b)
+			if len(dg.Data) >= int(dataLength) {
+				state = AwaitingCrc0
+			}
+
+		case AwaitingCrc0:
+			crcReceived = uint16(b) << 8
+			state = AwaitingCrc1
+
+		case AwaitingCrc1:
+			crcReceived |= uint16(b)
+			crcCalculated := crc.Get()
+			if crcCalculated != crcReceived {
+				// fmt.Printf("[CRC error calc %04x want %04x]", crcCalculated, crcReceived)
+				state = CRCError // CRCError
+				break LOOP
+			}
+
+			state = Done
+			fallthrough
+
+		case Done:
+			// fmt.Println("state", state)
+			break LOOP
+		}
+
+		// fmt.Println("state", state)
+	}
+	// fmt.Printf("(%v)\n", state)
+
+	if state != Done {
+		return nil, n, &RecoverableError{fmt.Sprintf("parsing failed in state %d", state)}
+	}
+
+	return &dg, n, nil
 }

--- a/recoverable.go
+++ b/recoverable.go
@@ -6,6 +6,6 @@ type RecoverableError struct {
 }
 
 // Prints error to string
-func (e RecoverableError) Error() string {
+func (e *RecoverableError) Error() string {
 	return e.Err
 }


### PR DESCRIPTION
Fix https://github.com/mlnoga/rct/issues/19

This PR adds a streaming reveicer and parser to handle RCT messages asynchronously. It has the following changes:

- connection continuously reads incoming data
- data is continuously being parsed by channel-based ParseAsync
- async parser adds support for long messages that didn't fit the buffer size before
- responses are cached for use with the synchronous Get api (to be removed?)
- the synchronous Query/Get api is complemented by channel-based Subscribe/Unsubscribe
- connection cache is removed- it's no longer needed
- legacy sychronous Parser is deprecated

TODO

- [ ] deduplicate legacy parser code
- [ ] decide async api removal (including the cache)
- [x] make broker private
- [ ] make QueryXYZ connection methods global

Since this PR breaks the existing API, it should be behind a v2 version.